### PR TITLE
Include both the current classloader along with the annotation processor

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/ErrorPronePlugins.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorPronePlugins.java
@@ -16,33 +16,38 @@
 
 package com.google.errorprone;
 
+import java.util.ServiceLoader;
+
+import javax.tools.JavaFileManager;
+import javax.tools.StandardLocation;
+
 import com.google.common.collect.Iterables;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.scanner.ScannerSupplier;
 import com.sun.tools.javac.processing.JavacProcessingEnvironment;
 import com.sun.tools.javac.util.Context;
-import java.util.ServiceLoader;
-import javax.tools.JavaFileManager;
-import javax.tools.StandardLocation;
 
 /** Loads custom Error Prone checks from the annotation processor classpath. */
 public class ErrorPronePlugins {
 
   public static ScannerSupplier loadPlugins(ScannerSupplier scannerSupplier, Context context) {
     JavaFileManager fileManager = context.get(JavaFileManager.class);
-    // Unlike in annotation processor discovery, we never search CLASS_PATH if
-    // ANNOTATION_PROCESSOR_PATH is unavailable.
-    if (!fileManager.hasLocation(StandardLocation.ANNOTATION_PROCESSOR_PATH)) {
-      return scannerSupplier;
+
+    ClassLoader loader;
+
+    if (fileManager.hasLocation(StandardLocation.ANNOTATION_PROCESSOR_PATH)) {
+      // If the annotation processor path is available, just use that.
+      JavacProcessingEnvironment processingEnvironment = JavacProcessingEnvironment.instance(context);
+      loader = processingEnvironment.getProcessorClassLoader();
+    } else {
+      loader = ErrorPronePlugins.class.getClassLoader();
     }
-    // Use the same classloader that Error Prone was loaded from to avoid classloader skew
-    // when using Error Prone plugins together with the Error Prone javac plugin.
-    JavacProcessingEnvironment processingEnvironment = JavacProcessingEnvironment.instance(context);
-    ClassLoader loader = processingEnvironment.getProcessorClassLoader();
+
     Iterable<BugChecker> extraBugCheckers = ServiceLoader.load(BugChecker.class, loader);
     if (Iterables.isEmpty(extraBugCheckers)) {
       return scannerSupplier;
     }
+
     return scannerSupplier.plus(
         ScannerSupplier.fromBugCheckerClasses(
             Iterables.transform(extraBugCheckers, BugChecker::getClass)));


### PR DESCRIPTION
This allows one to not use the annotation processor method of including
extra checks.