### PR TITLE
Add a hubspot import organizer.

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/ImportOrderParser.java
+++ b/check_api/src/main/java/com/google/errorprone/ImportOrderParser.java
@@ -36,6 +36,8 @@ public class ImportOrderParser {
         return ImportOrganizer.ANDROID_STATIC_FIRST_ORGANIZER;
       case "android-static-last":
         return ImportOrganizer.ANDROID_STATIC_LAST_ORGANIZER;
+      case "hubspot":
+        return ImportOrganizer.HUBSPOT_IMPORT_ORGANIZER;
       default:
         throw new IllegalStateException("Unknown import order: '" + importOrder + "'");
     }

--- a/check_api/src/main/java/com/google/errorprone/apply/HubSpotImportOrganizer.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/HubSpotImportOrganizer.java
@@ -1,0 +1,61 @@
+package com.google.errorprone.apply;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
+/**
+ * Organizes imports according to hubspot's style guide.
+ */
+class HubSpotImportOrganizer implements ImportOrganizer {
+  HubSpotImportOrganizer() {
+  }
+
+  private enum ImportGroup {
+    STATIC,
+    JAVA,
+    JAVAX,
+    ORG,
+    COM,
+    OTHER
+  }
+
+  @Override
+  public OrganizedImports organizeImports(List<Import> imports) {
+    OrganizedImports organized = new OrganizedImports();
+
+    // Group into static and non-static.
+    Multimap<ImportGroup, Import> importsByGroup = ArrayListMultimap.create();
+
+    for (Import i : imports) {
+      if (i.isStatic()) {
+        importsByGroup.put(ImportGroup.STATIC, i);
+      } else if (i.getType().startsWith("java.")) {
+        importsByGroup.put(ImportGroup.JAVA, i);
+      } else if (i.getType().startsWith("javax.")) {
+        importsByGroup.put(ImportGroup.JAVAX, i);
+      } else if (i.getType().startsWith("org.")) {
+        importsByGroup.put(ImportGroup.ORG, i);
+      } else if (i.getType().startsWith("com.")) {
+        importsByGroup.put(ImportGroup.COM, i);
+      } else {
+        importsByGroup.put(ImportGroup.OTHER, i);
+      }
+    }
+    Map<ImportGroup, List<Import>> sortedGroups = new HashMap<>();
+    for (ImportGroup group : importsByGroup.keySet()) {
+      List<Import> groupImports = new ArrayList<>(importsByGroup.get(group));
+      groupImports.sort(Comparator.comparing(Import::getType));
+      sortedGroups.put(group, groupImports);
+    }
+    // use the order of the enum to list our import blocks.
+    organized.addGroups(sortedGroups, Arrays.asList(ImportGroup.values()));
+    return organized;
+  }
+}

--- a/check_api/src/main/java/com/google/errorprone/apply/ImportOrganizer.java
+++ b/check_api/src/main/java/com/google/errorprone/apply/ImportOrganizer.java
@@ -89,6 +89,9 @@ public interface ImportOrganizer {
   ImportOrganizer ANDROID_STATIC_LAST_ORGANIZER =
       new AndroidImportOrganizer(StaticOrder.STATIC_LAST);
 
+  ImportOrganizer HUBSPOT_IMPORT_ORGANIZER =
+      new HubSpotImportOrganizer();
+
   /** Represents an import. */
   @AutoValue
   abstract class Import {


### PR DESCRIPTION
This patch enables ` -XepPatchImportOrder:hubspot` to be specified, which
makes it so that suggestions that mutate imports will preserve the HubSpot
style guide.

@kmclarnon 