### PR TITLE
Look in the unnamed module in addition to java_base

### DIFF
--- a/core/src/main/java/com/google/errorprone/refaster/Inliner.java
+++ b/core/src/main/java/com/google/errorprone/refaster/Inliner.java
@@ -21,11 +21,13 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.errorprone.SubContext;
+import com.google.errorprone.matchers.Enclosing.Class;
 import com.google.errorprone.refaster.Bindings.Key;
 import com.google.errorprone.refaster.UTypeVar.TypeWithExpression;
 import com.google.errorprone.util.ASTHelpers;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
+import com.sun.tools.javac.code.Symbol.ModuleSymbol;
 import com.sun.tools.javac.code.Symbol.TypeSymbol;
 import com.sun.tools.javac.code.Symbol.TypeVariableSymbol;
 import com.sun.tools.javac.code.Symtab;
@@ -83,17 +85,24 @@ public final class Inliner {
   public ClassSymbol resolveClass(CharSequence qualifiedClass)
       throws CouldNotResolveImportException {
     try {
-      Symbol symbol =
-          JavaCompiler.instance(context)
-              .resolveIdent(symtab().java_base, qualifiedClass.toString());
-      if (symbol.equals(symtab().errSymbol) || !(symbol instanceof ClassSymbol)) {
-        throw new CouldNotResolveImportException(qualifiedClass);
+      java.util.Optional<ClassSymbol> javaBase = resolveIdent(symtab().java_base, qualifiedClass);
+      if (javaBase.isPresent()) {
+        return javaBase.get();
       } else {
-        return (ClassSymbol) symbol;
+        return resolveIdent(symtab().unnamedModule, qualifiedClass)
+            .orElseThrow(() -> new CouldNotResolveImportException(qualifiedClass));
       }
     } catch (NullPointerException e) {
       throw new CouldNotResolveImportException(qualifiedClass);
     }
+  }
+
+  private java.util.Optional<ClassSymbol> resolveIdent(ModuleSymbol moduleSymbol, CharSequence qualifiedClass) {
+    Symbol symbol = JavaCompiler.instance(context).resolveIdent(moduleSymbol, qualifiedClass.toString());
+
+    return java.util.Optional.ofNullable(symbol)
+        .filter(ClassSymbol.class::isInstance)
+        .map(ClassSymbol.class::cast);
   }
 
   public Context getContext() {


### PR DESCRIPTION
The default class resolution logic in refaster only looks in the `java_base` symbol table. This means that any classes not defined in the JDK will not be found by refaster when resolving things like method return types in refaster templates, something [refaster does](https://github.com/google/error-prone/blob/6fe51560740276302ccd0b117640b8e24666c6ad/core/src/main/java/com/google/errorprone/refaster/ExpressionTemplate.java#L188) as part of handling edge cases around typing. Worse still, this import error was silently swallowed and not reported, so it isn't at all clear what happens.

This was leading to a bizarre situation where this template would "match" nothing:

```java
    @BeforeTemplate
    CharMatcher before() {
      return CharMatcher.ANY;
    }
```

but _this_ template would work as expected:

```java
    @BeforeTemplate
    Object before() {
      return CharMatcher.ANY;
    }
```

This is because refaster would be unable to find the return type CharMatcher in the java base symbol table, so it would just assume that the types didn't match and ignore it due to https://github.com/google/error-prone/blob/6fe51560740276302ccd0b117640b8e24666c6ad/core/src/main/java/com/google/errorprone/refaster/ExpressionTemplate.java#L212

This PR is a bit of a band-aid fix, since I won't pretend to know all the ins and outs of the symbol table. We check java base first and, if not found, go on to the unnamed module. It's possible (likely?) that this is still broken for anything that uses a type that's in a _module_. (eg, the java compiler tools stuff from jdk9 onwards)

We'll probably want to open an issue upstream for this as well.

cc @kmclarnon @stevegutz 