### PR TITLE
Support matching anonymous classes with placeholders

### DIFF
--- a/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
@@ -334,6 +334,11 @@ public class TemplateIntegrationTest extends CompilerBasedTest {
   }
 
   @Test
+  public void placeholderAllowsGenerics() throws IOException {
+    runTest("PlaceholderAllowsGenericsTemplate");
+  }
+
+  @Test
   public void unnecessaryLambdaParens() throws IOException {
     runTest("UnnecessaryLambdaParens");
   }

--- a/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
@@ -218,6 +218,11 @@ public class TemplateIntegrationTest extends CompilerBasedTest {
   }
 
   @Test
+  public void expressionPlaceholderAllowsAnonymousClasses() throws IOException {
+    runTest("PlaceholderSupportsAnonymousClassTemplate");
+  }
+
+  @Test
   public void blockPlaceholder() throws IOException {
     runTest("BlockPlaceholderTemplate");
   }

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/input/PlaceholderAllowsGenericsTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/input/PlaceholderAllowsGenericsTemplateExample.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterators;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+/**
+ * Test data for {@code PlaceholderTemplate}.
+ */
+public class PlaceholderSupportsAnonymousClassTemplateExample {
+  public void positiveExample(
+      ListenableFuture<String> listenableFuture,
+      FutureCallback<String> futureCallback) {
+    Futures.addCallback(listenableFuture, futureCallback);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/input/PlaceholderSupportsAnonymousClassTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/input/PlaceholderSupportsAnonymousClassTemplateExample.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterators;
+
+/**
+ * Test data for {@code PlaceholderSupportsAnonymousClassTemplate}.
+ */
+public class PlaceholderSupportsAnonymousClassTemplateExample {
+  public void positiveExample() {
+    Iterators.getLast(new AbstractIterator<Object>(){
+      @Override
+      protected Object computeNext() {
+        return null;
+      }
+    });
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/output/PlaceholderAllowsGenericsTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/output/PlaceholderAllowsGenericsTemplateExample.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterators;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+
+/**
+ * Test data for {@code PlaceholderTemplate}.
+ */
+public class PlaceholderSupportsAnonymousClassTemplateExample {
+  public void positiveExample(
+      ListenableFuture<String> listenableFuture,
+      FutureCallback<String> futureCallback) {
+    Futures.addCallback(listenableFuture, futureCallback, MoreExecutors.directExecutor());
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/output/PlaceholderSupportsAnonymousClassTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/output/PlaceholderSupportsAnonymousClassTemplateExample.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterators;
+
+/**
+ * Test data for {@code PlaceholderSupportsAnonymousClassTemplate}.
+ */
+public class PlaceholderSupportsAnonymousClassTemplateExample {
+  public void positiveExample() {
+    Iterators.getLast(new AbstractIterator<Object>(){
+      @Override
+      protected Object computeNext() {
+        return null;
+      }
+    }, null);
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/template/PlaceholderAllowsGenericsTemplate.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/template/PlaceholderAllowsGenericsTemplate.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata.template;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.Placeholder;
+
+/**
+ * Test case demonstrating use of Refaster placeholder methods.
+ *
+ * @author lowasser@google.com (Louis Wasserman)
+ */
+public abstract class PlaceholderSupportsAnonymousClassTemplate<V> {
+  @BeforeTemplate
+  void before() {
+    Futures.addCallback(someFuture(), someCallback());
+  }
+
+  // Contrived example
+
+  @AfterTemplate
+  void after() {
+    Futures.addCallback(someFuture(), someCallback(), MoreExecutors.directExecutor());
+  }
+
+  @Placeholder
+  abstract ListenableFuture<V> someFuture();
+
+  @Placeholder
+  abstract FutureCallback<V> someCallback();
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/template/PlaceholderSupportsAnonymousClassTemplate.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/template/PlaceholderSupportsAnonymousClassTemplate.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata.template;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.Executors;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.Placeholder;
+
+/**
+ * Test case demonstrating use of Refaster placeholder methods
+ * to match anonymous classes.
+ *
+ * @author mketelaar@hubspot.com (Megan Ketelaar)
+ */
+public abstract class PlaceholderSupportsAnonymousClassTemplate<E> {
+  @BeforeTemplate
+  void before() {
+    Iterators.getLast(someIterator());
+  }
+
+  // Contrived example
+
+  @AfterTemplate
+  void after() {
+    Iterators.getLast(someIterator(), null);
+  }
+
+  @Placeholder
+  abstract Iterator<E> someIterator();
+}


### PR DESCRIPTION
Refaster doesn't support matching anonymous classes with placeholders, so I took a stab at it. It's probably not the "perfect" way to do this but it works well enough.

@kmclarnon @stevegutz 