### PR TITLE
Support JDK9+ modules

### DIFF
--- a/core/src/main/java/com/google/errorprone/refaster/Inliner.java
+++ b/core/src/main/java/com/google/errorprone/refaster/Inliner.java
@@ -84,8 +84,7 @@ public final class Inliner {
       throws CouldNotResolveImportException {
     try {
       Symbol symbol =
-          JavaCompiler.instance(context)
-              .resolveIdent(symtab().java_base, qualifiedClass.toString());
+          JavaCompiler.instance(context).resolveBinaryNameOrIdent(qualifiedClass.toString());
       if (symbol.equals(symtab().errSymbol) || !(symbol instanceof ClassSymbol)) {
         throw new CouldNotResolveImportException(qualifiedClass);
       } else {

--- a/core/src/test/java/com/google/errorprone/refaster/AbstractUTreeTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/AbstractUTreeTest.java
@@ -20,11 +20,13 @@ import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.common.base.Joiner;
 import com.sun.tools.javac.file.JavacFileManager;
+import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.parser.Parser;
 import com.sun.tools.javac.parser.ParserFactory;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCIdent;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.List;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Before;
@@ -44,6 +46,8 @@ public abstract class AbstractUTreeTest {
   public void createContext() {
     context = new Context();
     JavacFileManager.preRegister(context);
+    JavaCompiler compiler = JavaCompiler.instance(context);
+    compiler.initModules(List.nil());
     unifier = new Unifier(context);
     inliner = unifier.createInliner();
   }

--- a/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
+++ b/core/src/test/java/com/google/errorprone/refaster/TemplateIntegrationTest.java
@@ -347,4 +347,9 @@ public class TemplateIntegrationTest extends CompilerBasedTest {
   public void unnecessaryLambdaParens() throws IOException {
     runTest("UnnecessaryLambdaParens");
   }
+
+  @Test
+  public void nonJdkType() throws IOException {
+    runTest("NonJdkTypeTemplate");
+  }
 }

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/input/NonJdkTypeTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/input/NonJdkTypeTemplateExample.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2014 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+import com.google.common.collect.ImmutableList;
+import java.util.stream.Stream;
+
+/** Test data for {@code NonJdkTypeTemplate}. */
+public class NonJdkTypeTemplateExample {
+  ImmutableList<Integer> example() {
+    return ImmutableList.copyOf(Stream.of(1).iterator());
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/output/NonJdkTypeTemplateExample.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/output/NonJdkTypeTemplateExample.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2014 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.refaster.testdata;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
+import java.util.stream.Stream;
+
+/** Test data for {@code NonJdkTypeTemplate}. */
+public class NonJdkTypeTemplateExample {
+  ImmutableList<Integer> example() {
+    return Stream.of(1).collect(toImmutableList());
+  }
+}

--- a/core/src/test/java/com/google/errorprone/refaster/testdata/template/NonJdkTypeTemplate.java
+++ b/core/src/test/java/com/google/errorprone/refaster/testdata/template/NonJdkTypeTemplate.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.errorprone.refaster.testdata.template;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.stream.Stream;
+
+/** Example template that uses a non-JDK type. */
+public class NonJdkTypeTemplate<T> {
+  @BeforeTemplate
+  public ImmutableList<T> before(Stream<T> stream) {
+    return ImmutableList.copyOf(stream.iterator());
+  }
+
+  @AfterTemplate
+  @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
+  public ImmutableList<T> after(Stream<T> stream) {
+    return stream.collect(toImmutableList());
+  }
+}


### PR DESCRIPTION
This is the better fix for JDK9+ issues, taken from https://github.com/PicnicSupermarket/error-prone/tree/bugfix/refaster-on-jdk-9-plus

@kmclarnon @stevegutz 