### PR TITLE
Update patch file path resolution

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/HubSpotPatchUtils.java
+++ b/check_api/src/main/java/com/google/errorprone/HubSpotPatchUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class HubSpotPatchUtils {
+  private static final String FILE_NAME_FMT = "error-prone-%s.patch";
+
+  public static Path resolvePatchFile(Path baseDir) {
+    Path defaultPath = baseDir.resolve("error-prone.patch");
+    if (Files.exists(defaultPath)) {
+      int i = 1;
+      Path curPath = getFileName(baseDir, i);
+      while (Files.exists(curPath)) {
+        i++;
+        curPath = getFileName(baseDir, i);
+      }
+
+      return curPath;
+    } else {
+      return defaultPath;
+    }
+  }
+
+  private static Path getFileName(Path baseDir, int id) {
+    return baseDir.resolve(String.format(FILE_NAME_FMT, id));
+  }
+
+  private HubSpotPatchUtils() {
+    throw new AssertionError() ;
+  }
+}

--- a/check_api/src/main/java/com/google/errorprone/RefactoringCollection.java
+++ b/check_api/src/main/java/com/google/errorprone/RefactoringCollection.java
@@ -95,7 +95,7 @@ class RefactoringCollection implements DescriptionListener.Factory {
                   RefactoringResultType.CHANGED);
     } else {
       Path baseDir = rootPath.resolve(patchingOptions.baseDirectory());
-      Path patchFilePath = baseDir.resolve("error-prone.patch");
+      Path patchFilePath = HubSpotPatchUtils.resolvePatchFile(baseDir);
 
       PatchFileDestination patchFileDestination = new PatchFileDestination(baseDir, rootPath);
       postProcess =

--- a/check_api/src/test/java/com/google/errorprone/HubSpotPatchUtilsTest.java
+++ b/check_api/src/test/java/com/google/errorprone/HubSpotPatchUtilsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Test;
+
+public class HubSpotPatchUtilsTest {
+
+  @Test
+  public void itIncrementsFileNames() throws Exception {
+    Path path = Files.createTempDirectory("patch-utils-test");
+
+    Path res1 = HubSpotPatchUtils.resolvePatchFile(path);
+    assertThat(res1.toString()).endsWith("error-prone.patch");
+
+    Files.createFile(path.resolve("error-prone.patch"));
+
+    Path res2 = HubSpotPatchUtils.resolvePatchFile(path);
+    assertThat(res2.toString()).endsWith("error-prone-1.patch");
+
+    Files.createFile(path.resolve("error-prone-1.patch"));
+
+    Path res3 = HubSpotPatchUtils.resolvePatchFile(path);
+    assertThat(res3.toString()).endsWith("error-prone-2.patch");
+  }
+}


### PR DESCRIPTION
The existing patch file behavior is extremely annoying when dealing with error prone inside maven, as even a single module will overwrite it's own patch file during test-compilation (if there are any test changes).  The current workaround is to use `IN_PLACE` and then  use git to stash those changes, but that becomes much more complicated during a reactor build.

This PR only changes a single line of the error-prone code to allow generation of sequential patch files in the already specified destination folder, so they can be gathered and applied later.

@stevegutz @Xcelled 