### PR TITLE
remove severity level

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/scanner/ScannerSupplier.java
+++ b/check_api/src/main/java/com/google/errorprone/scanner/ScannerSupplier.java
@@ -205,6 +205,7 @@ public abstract class ScannerSupplier implements Supplier<Scanner> {
             case DYNAMIC:
               // we do not want a severity override for a dynamic check, but
               // we must ensure that it is actually enabled
+              severities.remove(check.canonicalName());
               disabled.remove(check.canonicalName());
               break;
             case HIDDEN:


### PR DESCRIPTION
Turns out the default severity gets added here due to the merging of multiple scanner suppliers to get the final supplier, so we must explicitly remove it when we apply overrides

@stevegutz @Xcelled 