### PR TITLE
Account for backport of Java13 fix to Java 11

### DIFF
--- a/core/src/main/java/com/google/errorprone/refaster/Inliner.java
+++ b/core/src/main/java/com/google/errorprone/refaster/Inliner.java
@@ -236,7 +236,9 @@ public final class Inliner {
   private static void setUpperBound(TypeVar typeVar, Type bound) {
     try {
       // https://bugs.openjdk.java.net/browse/JDK-8193367
-      if (RuntimeVersion.isAtLeast13()) {
+      if (RuntimeVersion.isAtLeast11()) {
+        // This method is only in java 11.0.9 or later,
+        // but that should be fine because that's what we use
         TypeVar.class.getMethod("setUpperBound", Type.class).invoke(typeVar, bound);
       } else {
         TypeVar.class.getField("bound").set(typeVar, bound);


### PR DESCRIPTION
A fix was backported from Java13 to Java 11.0.9, which broke a refaster reflection assumption. Since we're on 11.0.9, I just changed the conditional to be 11. Checking the minor versions would required adding a lot more code as only major versions are currently easily accessible in error-prone.

@kmclarnon @stevegutz 