### PR TITLE
Make FutureReturnValueIgnored non-final so we can extend it 😉

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnored.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/FutureReturnValueIgnored.java
@@ -46,7 +46,7 @@ import java.util.concurrent.ForkJoinTask;
             + "suppresses exceptions thrown from the code that completes the Future.",
     severity = WARNING,
     tags = StandardTags.FRAGILE_CODE)
-public final class FutureReturnValueIgnored extends AbstractReturnValueIgnored
+public class FutureReturnValueIgnored extends AbstractReturnValueIgnored
     implements ReturnTreeMatcher {
 
   private static final Matcher<ExpressionTree> IGNORED_METHODS =


### PR DESCRIPTION
This should let us easily write our own version that doesn't complain about `ScheduledFuture`s

@kmclarnon @Xcelled 