### PR TITLE
Canonical suppressions

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/HubSpotUtils.java
+++ b/check_api/src/main/java/com/google/errorprone/HubSpotUtils.java
@@ -107,6 +107,17 @@ public class HubSpotUtils {
     return isErrorHandlingEnabled(options.getFlags());
   }
 
+  public static boolean isCanonicalSuppressionEnabled(VisitorState visitorState) {
+    ErrorProneFlags flags = visitorState.errorProneOptions().getFlags();
+    if (flags == null) {
+      return false;
+    }
+
+    return flags
+        .getBoolean("hubspot:canonical-suppression")
+        .orElse(false);
+  }
+
   public static void recordError(Suppressible s) {
     DATA.computeIfAbsent(EXCEPTIONS, ignored -> ConcurrentHashMap.newKeySet())
         .add(s.canonicalName());

--- a/check_api/src/main/java/com/google/errorprone/SuppressionInfo.java
+++ b/check_api/src/main/java/com/google/errorprone/SuppressionInfo.java
@@ -93,9 +93,17 @@ public class SuppressionInfo {
     if (inGeneratedCode && suppressedInGeneratedCode) {
       return SuppressedState.SUPPRESSED;
     }
-    if (suppressible.supportsSuppressWarnings()
-        && !Collections.disjoint(suppressible.allNames(), suppressWarningsStrings)) {
-      return SuppressedState.SUPPRESSED;
+
+    if (HubSpotUtils.isCanonicalSuppressionEnabled(state)) {
+      if (suppressible.supportsSuppressWarnings()
+          && suppressWarningsStrings.contains(suppressible.canonicalName())) {
+        return SuppressedState.SUPPRESSED;
+      }
+    } else {
+      if (suppressible.supportsSuppressWarnings()
+          && !Collections.disjoint(suppressible.allNames(), suppressWarningsStrings)) {
+        return SuppressedState.SUPPRESSED;
+      }
     }
     if (suppressible.suppressedByAnyOf(customSuppressions, state)) {
       return SuppressedState.SUPPRESSED;


### PR DESCRIPTION
This allows us to specify the `-XepOpt:hubspot:canonical-suppressions` flag when running error prone to ensure that suppressions will only be considered from `@SuppressWarnings` if it matches the canonical check name

@stevegutz @Xcelled 