### PR TITLE
Support generated code

### DIFF
--- a/annotation/src/main/java/com/google/errorprone/BugPattern.java
+++ b/annotation/src/main/java/com/google/errorprone/BugPattern.java
@@ -186,6 +186,9 @@ public @interface BugPattern {
    */
   Class<? extends Annotation>[] suppressionAnnotations() default SuppressWarnings.class;
 
+  /** True if this check should be invoked on generated code */
+  boolean inspectGeneratedCode() default false;
+
   /**
    * Generate an explanation of how to suppress the check.
    *

--- a/check_api/src/main/java/com/google/errorprone/BugCheckerInfo.java
+++ b/check_api/src/main/java/com/google/errorprone/BugCheckerInfo.java
@@ -74,6 +74,8 @@ public class BugCheckerInfo implements Serializable {
 
   private final boolean supportsSuppressWarnings;
 
+  private final boolean inspectGeneratedCode;
+
   /**
    * A set of suppression annotations for this check. Computed from the {@code
    * suppressionAnnotations} attributes from its {@code BugPattern}. May be empty if there are no
@@ -111,6 +113,7 @@ public class BugCheckerInfo implements Serializable {
         pattern.severity(),
         createLinkUrl(pattern),
         Stream.of(pattern.suppressionAnnotations()).anyMatch(a -> isSuppressWarnings(a)),
+        pattern.inspectGeneratedCode(),
         Stream.of(pattern.suppressionAnnotations())
             .filter(a -> !isSuppressWarnings(a))
             .collect(toImmutableSet()),
@@ -130,6 +133,7 @@ public class BugCheckerInfo implements Serializable {
       SeverityLevel defaultSeverity,
       String linkUrl,
       boolean supportsSuppressWarnings,
+      boolean inspectGeneratedCode,
       Set<Class<? extends Annotation>> customSuppressionAnnotations,
       ImmutableSet<String> tags,
       boolean disableable) {
@@ -140,6 +144,7 @@ public class BugCheckerInfo implements Serializable {
     this.defaultSeverity = defaultSeverity;
     this.linkUrl = linkUrl;
     this.supportsSuppressWarnings = supportsSuppressWarnings;
+    this.inspectGeneratedCode = inspectGeneratedCode;
     this.customSuppressionAnnotations = customSuppressionAnnotations;
     this.tags = tags;
     this.disableable = disableable;
@@ -162,6 +167,7 @@ public class BugCheckerInfo implements Serializable {
         defaultSeverity,
         linkUrl,
         supportsSuppressWarnings,
+        inspectGeneratedCode,
         customSuppressionAnnotations,
         tags,
         disableable);
@@ -217,6 +223,10 @@ public class BugCheckerInfo implements Serializable {
 
   public Set<Class<? extends Annotation>> customSuppressionAnnotations() {
     return Collections.unmodifiableSet(customSuppressionAnnotations);
+  }
+
+  public boolean inspectGeneratedCode() {
+    return inspectGeneratedCode;
   }
 
   public boolean disableable() {

--- a/check_api/src/main/java/com/google/errorprone/SuppressionInfo.java
+++ b/check_api/src/main/java/com/google/errorprone/SuppressionInfo.java
@@ -119,6 +119,10 @@ public class SuppressionInfo {
    * matchers on {@link CompilationUnitTree} will also be suppressed.
    */
   public SuppressionInfo forCompilationUnit(CompilationUnitTree tree, VisitorState state) {
+    if (HubSpotUtils.isGeneratedCodeInspectionEnabled(state)) {
+      return new SuppressionInfo(suppressWarningsStrings, customSuppressions, HubSpotUtils.isGenerated(state));
+    }
+
     AtomicBoolean generated = new AtomicBoolean(false);
     new SimpleTreeVisitor<Void, Void>() {
       @Override
@@ -148,7 +152,13 @@ public class SuppressionInfo {
    */
   public SuppressionInfo withExtendedSuppressions(
       Symbol sym, VisitorState state, Set<? extends Name> customSuppressionAnnosToLookFor) {
-    boolean newInGeneratedCode = inGeneratedCode || isGenerated(sym, state);
+    boolean newInGeneratedCode;
+    if (HubSpotUtils.isGeneratedCodeInspectionEnabled(state)) {
+      newInGeneratedCode = inGeneratedCode || HubSpotUtils.isGenerated(state);
+    } else {
+      newInGeneratedCode = inGeneratedCode || isGenerated(sym, state);
+    }
+
     boolean anyModification = newInGeneratedCode != inGeneratedCode;
 
     /* Handle custom suppression annotations. */

--- a/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotUtils.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotUtils.java
@@ -17,8 +17,11 @@
 package com.google.errorprone.hubspot;
 
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -71,7 +74,7 @@ public class HubSpotUtils {
   private static final Map<String, Set<String>> DATA = loadExistingData();
   private static final Map<String, Long> PREVIOUS_TIMING_DATA = loadExistingTimings();
   private static final Map<String, Long> TIMING_DATA = new ConcurrentHashMap<>();
-  private static final Supplier<Pattern> GENERATED_PATTERN = VisitorState.memoize(getGeneratedPathsPattern());
+  private static final Supplier<PathMatcher> GENERATED_PATTERN = VisitorState.memoize(getGeneratedPathsMatcher());
 
   public static ScannerSupplier createScannerSupplier(Iterable<BugChecker> extraBugCheckers) {
     ImmutableList.Builder<BugCheckerInfo> builder = ImmutableList.builder();
@@ -121,8 +124,7 @@ public class HubSpotUtils {
   public static boolean isGenerated(VisitorState state) {
     return GENERATED_PATTERN
         .get(state)
-        .matcher(ASTHelpers.getFileName(state.getPath().getCompilationUnit()))
-        .matches();
+        .matches(Paths.get(ASTHelpers.getFileName(state.getPath().getCompilationUnit())));
   }
 
   public static void recordError(Suppressible s) {
@@ -149,10 +151,10 @@ public class HubSpotUtils {
     });
   }
 
-  private static Supplier<Pattern> getGeneratedPathsPattern() {
+  private static Supplier<PathMatcher> getGeneratedPathsMatcher() {
     return visitorState -> Optional.ofNullable(visitorState.errorProneOptions().getFlags())
         .flatMap(f -> f.get(GENERATED_SOURCES_FLAG))
-        .map(Pattern::compile)
+        .map(s -> FileSystems.getDefault().getPathMatcher(s))
         .orElseThrow(() -> new IllegalStateException("Must specify flag " + GENERATED_SOURCES_FLAG));
   }
 

--- a/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotUtils.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotUtils.java
@@ -24,9 +24,10 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.databind.JavaType;
 import com.google.common.base.Strings;
@@ -43,6 +44,8 @@ import com.google.errorprone.descriptionlistener.CustomDescriptionListenerFactor
 import com.google.errorprone.descriptionlistener.DescriptionListenerResources;
 import com.google.errorprone.matchers.Suppressible;
 import com.google.errorprone.scanner.ScannerSupplier;
+import com.google.errorprone.suppliers.Supplier;
+import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.util.JavacTask;
 import com.sun.tools.javac.api.BasicJavacTask;
 import com.sun.tools.javac.util.Context;
@@ -64,9 +67,11 @@ public class HubSpotUtils {
   private static final String INIT_ERROR = "errorProneInitErrors";
   private static final String LISTENER_INIT_ERRORS = "errorProneListenerInitErrors";
   private static final String ERROR_REPORTING_FLAG = "hubspot:error-reporting";
+  private static final String GENERATED_SOURCES_FLAG = "hubspot:generated-sources-pattern";
   private static final Map<String, Set<String>> DATA = loadExistingData();
   private static final Map<String, Long> PREVIOUS_TIMING_DATA = loadExistingTimings();
   private static final Map<String, Long> TIMING_DATA = new ConcurrentHashMap<>();
+  private static final Supplier<Pattern> GENERATED_PATTERN = VisitorState.memoize(getGeneratedPathsPattern());
 
   public static ScannerSupplier createScannerSupplier(Iterable<BugChecker> extraBugCheckers) {
     ImmutableList.Builder<BugCheckerInfo> builder = ImmutableList.builder();
@@ -109,6 +114,17 @@ public class HubSpotUtils {
     return isFlagEnabled("hubspot:canonical-suppressions-only", visitorState.errorProneOptions());
   }
 
+  public static boolean isGeneratedCodeInspectionEnabled(VisitorState visitorState) {
+    return isFlagEnabled("hubspot:generated-code-inspection", visitorState.errorProneOptions());
+  }
+
+  public static boolean isGenerated(VisitorState state) {
+    return GENERATED_PATTERN
+        .get(state)
+        .matcher(ASTHelpers.getFileName(state.getPath().getCompilationUnit()))
+        .matches();
+  }
+
   public static void recordError(Suppressible s) {
     DATA.computeIfAbsent(EXCEPTIONS, ignored -> ConcurrentHashMap.newKeySet())
         .add(s.canonicalName());
@@ -131,6 +147,13 @@ public class HubSpotUtils {
       FileManager.getErrorOutputPath().ifPresent(p -> FileManager.write(DATA, p));
       FileManager.getTimingsOutputPath().ifPresent(p -> FileManager.write(computeFinalTimings(), p));
     });
+  }
+
+  private static Supplier<Pattern> getGeneratedPathsPattern() {
+    return visitorState -> Optional.ofNullable(visitorState.errorProneOptions().getFlags())
+        .flatMap(f -> f.get(GENERATED_SOURCES_FLAG))
+        .map(Pattern::compile)
+        .orElseThrow(() -> new IllegalStateException("Must specify flag " + GENERATED_SOURCES_FLAG));
   }
 
   private static boolean isFlagEnabled(String flag, ErrorProneOptions errorProneOptions) {

--- a/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotUtils.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotUtils.java
@@ -63,6 +63,7 @@ public class HubSpotUtils {
   private static final String MISSING = "errorProneMissingChecks";
   private static final String INIT_ERROR = "errorProneInitErrors";
   private static final String LISTENER_INIT_ERRORS = "errorProneListenerInitErrors";
+  private static final String ERROR_REPORTING_FLAG = "hubspot:error-reporting";
   private static final Map<String, Set<String>> DATA = loadExistingData();
   private static final Map<String, Long> PREVIOUS_TIMING_DATA = loadExistingTimings();
   private static final Map<String, Long> TIMING_DATA = new ConcurrentHashMap<>();
@@ -97,22 +98,15 @@ public class HubSpotUtils {
   }
 
   public static boolean isErrorHandlingEnabled(DescriptionListenerResources resources) {
-    return isErrorHandlingEnabled(resources.getContext().get(ErrorProneFlags.class));
+    return isFlagEnabled(ERROR_REPORTING_FLAG, resources.getContext().get(ErrorProneFlags.class));
   }
 
   public static boolean isErrorHandlingEnabled(ErrorProneOptions options) {
-    return isErrorHandlingEnabled(options.getFlags());
+    return isFlagEnabled(ERROR_REPORTING_FLAG, options);
   }
 
   public static boolean isCanonicalSuppressionEnabled(VisitorState visitorState) {
-    ErrorProneFlags flags = visitorState.errorProneOptions().getFlags();
-    if (flags == null) {
-      return false;
-    }
-
-    return flags
-        .getBoolean("hubspot:canonical-suppressions-only")
-        .orElse(false);
+    return isFlagEnabled("hubspot:canonical-suppressions-only", visitorState.errorProneOptions());
   }
 
   public static void recordError(Suppressible s) {
@@ -139,13 +133,17 @@ public class HubSpotUtils {
     });
   }
 
-  private static boolean isErrorHandlingEnabled(ErrorProneFlags flags) {
+  private static boolean isFlagEnabled(String flag, ErrorProneOptions errorProneOptions) {
+    return isFlagEnabled(flag, errorProneOptions.getFlags());
+  }
+
+  private static boolean isFlagEnabled(String flag, ErrorProneFlags flags) {
     if (flags == null) {
       return false;
     }
 
     return flags
-        .getBoolean("hubspot:error-reporting")
+        .getBoolean(flag)
         .orElse(false);
   }
 

--- a/check_api/src/main/java/com/google/errorprone/matchers/Suppressible.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Suppressible.java
@@ -36,7 +36,9 @@ public interface Suppressible {
   boolean supportsSuppressWarnings();
 
   /** Return true if this checker should run on generated code */
-  boolean inspectGeneratedCode();
+  default boolean inspectGeneratedCode() {
+    return false;
+  }
 
   /** Returns the custom suppression annotations for this checker, if custom suppression is used. */
   Set<Class<? extends Annotation>> customSuppressionAnnotations();

--- a/check_api/src/main/java/com/google/errorprone/matchers/Suppressible.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Suppressible.java
@@ -35,6 +35,9 @@ public interface Suppressible {
   /** Returns true if this checker can be suppressed using {@code @SuppressWarnings}. */
   boolean supportsSuppressWarnings();
 
+  /** Return true if this checker should run on generated code */
+  boolean inspectGeneratedCode();
+
   /** Returns the custom suppression annotations for this checker, if custom suppression is used. */
   Set<Class<? extends Annotation>> customSuppressionAnnotations();
 

--- a/check_api/src/main/java/com/google/errorprone/scanner/Scanner.java
+++ b/check_api/src/main/java/com/google/errorprone/scanner/Scanner.java
@@ -25,6 +25,7 @@ import com.google.errorprone.SuppressionInfo;
 import com.google.errorprone.SuppressionInfo.SuppressedState;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.annotations.CheckReturnValue;
+import com.google.errorprone.hubspot.HubSpotUtils;
 import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Suppressible;
 import com.google.errorprone.util.ASTHelpers;
@@ -107,9 +108,9 @@ public class Scanner extends TreePathScanner<Void, VisitorState> {
   protected SuppressedState isSuppressed(
       Suppressible suppressible, ErrorProneOptions errorProneOptions, VisitorState state) {
 
-    boolean suppressedInGeneratedCode =
-        errorProneOptions.disableWarningsInGeneratedCode()
-            && severityMap().get(suppressible.canonicalName()) != SeverityLevel.ERROR;
+    boolean suppressedInGeneratedCode = !suppressible.inspectGeneratedCode()
+        || (errorProneOptions.disableWarningsInGeneratedCode()
+            && severityMap().get(suppressible.canonicalName()) != SeverityLevel.ERROR);
 
     return currentSuppressions.suppressedState(suppressible, suppressedInGeneratedCode, state);
   }

--- a/check_api/src/main/java/com/google/errorprone/scanner/Scanner.java
+++ b/check_api/src/main/java/com/google/errorprone/scanner/Scanner.java
@@ -108,9 +108,16 @@ public class Scanner extends TreePathScanner<Void, VisitorState> {
   protected SuppressedState isSuppressed(
       Suppressible suppressible, ErrorProneOptions errorProneOptions, VisitorState state) {
 
-    boolean suppressedInGeneratedCode = !suppressible.inspectGeneratedCode()
-        || (errorProneOptions.disableWarningsInGeneratedCode()
-            && severityMap().get(suppressible.canonicalName()) != SeverityLevel.ERROR);
+    final boolean suppressedInGeneratedCode;
+    if (HubSpotUtils.isGeneratedCodeInspectionEnabled(state)) {
+      suppressedInGeneratedCode = !suppressible.inspectGeneratedCode()
+          || (errorProneOptions.disableWarningsInGeneratedCode()
+          && severityMap().get(suppressible.canonicalName()) != SeverityLevel.ERROR);
+    } else {
+      suppressedInGeneratedCode =
+          errorProneOptions.disableWarningsInGeneratedCode()
+              && severityMap().get(suppressible.canonicalName()) != SeverityLevel.ERROR;
+    }
 
     return currentSuppressions.suppressedState(suppressible, suppressedInGeneratedCode, state);
   }


### PR DESCRIPTION
This PR does a few things:

1. A little bit of cleanup
2. Adds a `inspectGeneratedCode` flag (defaults to false) on the `BugPattern` annotation for check implementations
3. Adds a flag, `hubspot:generated-sources-pattern` to allow us to specify a regex that will be applied to compilation unit file paths.  A match indicates that the file is a generated source.  This is necessary because a number of our code generators do not annotate the sources they generate with `@javax.annotation.Generated`
4. Adds a flag, `hubspot:generated-code-inspection` to enable this new functionality, which will allow us to remove our exclusion of generated sources from error prone inspection, and instead only run checks with `inspectGeneratedCode` set to true on them.

Need to do a decent amount of testing before merging this

@stevegutz @Xcelled 