### PR TITLE
[UnusedVariable] Don't complain about unused org.slf4j.Logger fields

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
@@ -144,7 +144,7 @@ public final class UnusedVariable extends BugChecker implements CompilationUnitT
 
   /** The set of types exempting a field of type extending them. */
   private static final ImmutableSet<String> EXEMPTING_FIELD_SUPER_TYPES =
-      ImmutableSet.of("org.junit.rules.TestRule");
+      ImmutableSet.of("org.junit.rules.TestRule", "org.slf4j.Logger");
 
   private static final ImmutableList<String> SPECIAL_FIELDS =
       ImmutableList.of(


### PR DESCRIPTION
There are probably more things we need here, but this is the first one I found.

@kmclarnon @Xcelled @snommit-mit