### PR TITLE
Add UnusedVariable#shouldReport

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
@@ -115,7 +115,7 @@ import javax.lang.model.type.NullType;
     summary = "Unused.",
     severity = WARNING,
     documentSuppression = false)
-public final class UnusedVariable extends BugChecker implements CompilationUnitTreeMatcher {
+public class UnusedVariable extends BugChecker implements CompilationUnitTreeMatcher {
   private static final String EXEMPT_PREFIX = "unused";
 
   private static final ImmutableSet<String> EXEMPT_NAMES = ImmutableSet.of("ignored");
@@ -232,6 +232,11 @@ public final class UnusedVariable extends BugChecker implements CompilationUnitT
       } else {
         fixes = buildUnusedVarFixes(symbol, allUsageSites, state);
       }
+
+      if (!shouldReport(symbol, state, fixes)) {
+        continue;
+      }
+
       state.reportMatch(
           buildDescription(unused)
               .setMessage(
@@ -252,6 +257,10 @@ public final class UnusedVariable extends BugChecker implements CompilationUnitT
               .build());
     }
     return Description.NO_MATCH;
+  }
+
+  protected boolean shouldReport(VarSymbol symbol, VisitorState state, List<SuggestedFix> fixes) {
+    return true;
   }
 
   private static SuggestedFix makeAssignmentDeclaration(


### PR DESCRIPTION
This will allow us to subclass `UnusedVariable` and skip anything with potential side-effects, which will help a lot with trying to do an automated rollout. I don't know if we want more context in `shouldReport`, but we can always find ways to add more in the future.

@kmclarnon @Xcelled @snommit-mit 