### PR TITLE
[UnusedMethod] exempt @Before* and @After* methods

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedMethod.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedMethod.java
@@ -95,6 +95,10 @@ public final class UnusedMethod extends BugChecker implements CompilationUnitTre
           "javax.annotation.PostConstruct",
           "javax.persistence.PostLoad",
           "javax.inject.Inject",
+          "org.junit.jupiter.api.AfterAll",
+          "org.junit.jupiter.api.AfterEach",
+          "org.junit.jupiter.api.BeforeAll",
+          "org.junit.jupiter.api.BeforeEach",
           "org.testng.annotations.DataProvider");
 
   /** The set of types exempting a type that is extending or implementing them. */


### PR DESCRIPTION
These can be private in junit 5.

@kmclarnon @Xcelled @snommit-mit 