### PR TITLE
Log uncaught errors to a file

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
+++ b/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
@@ -97,7 +97,9 @@ public class BaseErrorProneJavaCompiler implements JavaCompiler {
     setupMessageBundle(context);
     RefactoringCollection[] refactoringCollection = {null};
     javacTask.addTaskListener(
-        HubSpotErrorProneAnalyzer.wrap(createAnalyzer(scannerSupplier, errorProneOptions, context, refactoringCollection)));
+        HubSpotErrorProneAnalyzer.wrap(
+            errorProneOptions,
+            createAnalyzer(scannerSupplier, errorProneOptions, context, refactoringCollection)));
     if (refactoringCollection[0] != null) {
       javacTask.addTaskListener(new RefactoringTask(context, refactoringCollection[0]));
     }

--- a/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
+++ b/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
@@ -20,6 +20,7 @@ import static com.google.common.base.StandardSystemProperty.JAVA_SPECIFICATION_V
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.RefactoringCollection.RefactoringResult;
+import com.google.errorprone.hubspot.HubSpotErrorProneAnalyzer;
 import com.google.errorprone.scanner.ErrorProneScannerTransformer;
 import com.google.errorprone.scanner.ScannerSupplier;
 import com.sun.source.util.JavacTask;
@@ -96,7 +97,7 @@ public class BaseErrorProneJavaCompiler implements JavaCompiler {
     setupMessageBundle(context);
     RefactoringCollection[] refactoringCollection = {null};
     javacTask.addTaskListener(
-        createAnalyzer(scannerSupplier, errorProneOptions, context, refactoringCollection));
+        HubSpotErrorProneAnalyzer.wrap(createAnalyzer(scannerSupplier, errorProneOptions, context, refactoringCollection)));
     if (refactoringCollection[0] != null) {
       javacTask.addTaskListener(new RefactoringTask(context, refactoringCollection[0]));
     }

--- a/check_api/src/main/java/com/google/errorprone/hubspot/FileManager.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/FileManager.java
@@ -46,6 +46,11 @@ class FileManager {
         .map(o -> o.resolve(String.format("lifecycle-canary-%s.json", id)));
   }
 
+  static Optional<Path> getUncaughtExceptionPath() {
+    return getDataDir(BLAZAR_DIR_ENV_VAR, "error-prone")
+        .map(o -> o.resolve("error-prone-exception.log"));
+  }
+
   static void write(Object data, Path path) {
     try (OutputStream stream = Files.newOutputStream(path)) {
       MAPPER.writerWithDefaultPrettyPrinter().writeValue(stream, data);

--- a/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotErrorProneAnalyzer.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotErrorProneAnalyzer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.hubspot;
+
+import com.google.errorprone.ErrorProneAnalyzer;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+
+public class HubSpotErrorProneAnalyzer implements TaskListener {
+  private final ErrorProneAnalyzer delegate;
+
+
+  public static HubSpotErrorProneAnalyzer wrap(ErrorProneAnalyzer analyzer) {
+    return new HubSpotErrorProneAnalyzer(analyzer);
+  }
+
+  private HubSpotErrorProneAnalyzer(ErrorProneAnalyzer delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void started(TaskEvent e) {
+    try {
+      delegate.started(e);
+    } catch (Throwable t) {
+      HubSpotUtils.recordUncaughtException(t);
+      throw t;
+    }
+  }
+
+  @Override
+  public void finished(TaskEvent e) {
+    try {
+      delegate.finished(e);
+    } catch (Throwable t) {
+      HubSpotUtils.recordUncaughtException(t);
+      throw t;
+    }
+  }
+}

--- a/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotErrorProneAnalyzer.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotErrorProneAnalyzer.java
@@ -17,6 +17,7 @@
 package com.google.errorprone.hubspot;
 
 import com.google.errorprone.ErrorProneAnalyzer;
+import com.google.errorprone.ErrorProneOptions;
 import com.sun.source.util.TaskEvent;
 import com.sun.source.util.TaskListener;
 
@@ -24,8 +25,12 @@ public class HubSpotErrorProneAnalyzer implements TaskListener {
   private final ErrorProneAnalyzer delegate;
 
 
-  public static HubSpotErrorProneAnalyzer wrap(ErrorProneAnalyzer analyzer) {
-    return new HubSpotErrorProneAnalyzer(analyzer);
+  public static TaskListener wrap(ErrorProneOptions options, ErrorProneAnalyzer analyzer) {
+    if (HubSpotUtils.isErrorHandlingEnabled(options)) {
+      return new HubSpotErrorProneAnalyzer(analyzer);
+    } else {
+      return analyzer;
+    }
   }
 
   private HubSpotErrorProneAnalyzer(ErrorProneAnalyzer delegate) {

--- a/core/src/main/java/com/google/errorprone/ErrorProneJavacPlugin.java
+++ b/core/src/main/java/com/google/errorprone/ErrorProneJavacPlugin.java
@@ -33,7 +33,12 @@ public class ErrorProneJavacPlugin implements Plugin {
   @Override
   public void init(JavacTask javacTask, String... args) {
     HubSpotUtils.init(javacTask);
-    BaseErrorProneJavaCompiler.addTaskListener(
-        javacTask, BuiltInCheckerSuppliers.defaultChecks(), ErrorProneOptions.processArgs(args));
+    try {
+      BaseErrorProneJavaCompiler.addTaskListener(
+          javacTask, BuiltInCheckerSuppliers.defaultChecks(), ErrorProneOptions.processArgs(args));
+    } catch (Throwable t) {
+      HubSpotUtils.recordUncaughtException(t);
+      throw t;
+    }
   }
 }

--- a/core/src/main/java/com/google/errorprone/ErrorProneJavacPlugin.java
+++ b/core/src/main/java/com/google/errorprone/ErrorProneJavacPlugin.java
@@ -32,9 +32,9 @@ public class ErrorProneJavacPlugin implements Plugin {
 
   @Override
   public void init(JavacTask javacTask, String... args) {
-    HubSpotUtils.init(javacTask);
     ErrorProneOptions options = null;
     try {
+      HubSpotUtils.init(javacTask);
       options = ErrorProneOptions.processArgs(args);
       BaseErrorProneJavaCompiler.addTaskListener(
           javacTask, BuiltInCheckerSuppliers.defaultChecks(), options);

--- a/core/src/main/java/com/google/errorprone/ErrorProneJavacPlugin.java
+++ b/core/src/main/java/com/google/errorprone/ErrorProneJavacPlugin.java
@@ -33,11 +33,14 @@ public class ErrorProneJavacPlugin implements Plugin {
   @Override
   public void init(JavacTask javacTask, String... args) {
     HubSpotUtils.init(javacTask);
+    ErrorProneOptions options = ErrorProneOptions.processArgs(args);
     try {
       BaseErrorProneJavaCompiler.addTaskListener(
-          javacTask, BuiltInCheckerSuppliers.defaultChecks(), ErrorProneOptions.processArgs(args));
+          javacTask, BuiltInCheckerSuppliers.defaultChecks(), options);
     } catch (Throwable t) {
-      HubSpotUtils.recordUncaughtException(t);
+      if (HubSpotUtils.isErrorHandlingEnabled(options)) {
+        HubSpotUtils.recordUncaughtException(t);
+      }
       throw t;
     }
   }

--- a/core/src/main/java/com/google/errorprone/ErrorProneJavacPlugin.java
+++ b/core/src/main/java/com/google/errorprone/ErrorProneJavacPlugin.java
@@ -33,12 +33,13 @@ public class ErrorProneJavacPlugin implements Plugin {
   @Override
   public void init(JavacTask javacTask, String... args) {
     HubSpotUtils.init(javacTask);
-    ErrorProneOptions options = ErrorProneOptions.processArgs(args);
+    ErrorProneOptions options = null;
     try {
+      options = ErrorProneOptions.processArgs(args);
       BaseErrorProneJavaCompiler.addTaskListener(
           javacTask, BuiltInCheckerSuppliers.defaultChecks(), options);
     } catch (Throwable t) {
-      if (HubSpotUtils.isErrorHandlingEnabled(options)) {
+      if (options == null || HubSpotUtils.isErrorHandlingEnabled(options)) {
         HubSpotUtils.recordUncaughtException(t);
       }
       throw t;


### PR DESCRIPTION
This will write out the exception & stacktrace to a file in the viewable artifacts directory whenever there is an uncaught exception in the error-prone plugin.

@stevegutz @Xcelled @snommit-mit 