### PR TITLE
Fully replace the analyzer with our wrapper

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
+++ b/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
@@ -98,6 +98,7 @@ public class BaseErrorProneJavaCompiler implements JavaCompiler {
     RefactoringCollection[] refactoringCollection = {null};
     javacTask.addTaskListener(
         HubSpotErrorProneAnalyzer.wrap(
+            context,
             errorProneOptions,
             createAnalyzer(scannerSupplier, errorProneOptions, context, refactoringCollection)));
     if (refactoringCollection[0] != null) {

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
@@ -117,17 +117,7 @@ public class ErrorProneAnalyzer implements TaskListener {
   private int errorProneErrors = 0;
 
   @Override
-  public void started(TaskEvent taskEvent) {
-    if (taskEvent.getKind() == Kind.COMPILATION) {
-      HubSpotLifecycleManager.instance(context).handleStartup();
-    }
-  }
-
-  @Override
   public void finished(TaskEvent taskEvent) {
-    if (taskEvent.getKind() == Kind.COMPILATION) {
-      HubSpotLifecycleManager.instance(context).handleShutdown();
-    }
     if (taskEvent.getKind() != Kind.ANALYZE) {
       return;
     }


### PR DESCRIPTION
A prereq to implementing module-based checks, we need to always use our custom analyzer wrapper. This consolidates the functionality changes into the HubspotErrorProneAnalyzer class and changes the code to always use that class.

@stevegutz @kmclarnon @snommit-mit 