### PR TITLE
Support severity overrides for module checks

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/hubspot/module/ModuleDescription.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/module/ModuleDescription.java
@@ -17,6 +17,7 @@
 package com.google.errorprone.hubspot.module;
 
 import com.google.common.base.Preconditions;
+import com.google.errorprone.BugPattern.SeverityLevel;
 import com.google.errorprone.matchers.Description;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.tree.JCTree.JCCompilationUnit;
@@ -52,7 +53,15 @@ public class ModuleDescription {
     return description;
   }
 
+  public String getCheckName() {
+    return description.checkName;
+  }
+
   public JCCompilationUnit getCompilationUnit() {
     return compilationUnit;
+  }
+
+  public ModuleDescription applySeverityOverride(SeverityLevel severityLevel) {
+    return new ModuleDescription(description.applySeverityOverride(severityLevel), compilationUnit);
   }
 }

--- a/check_api/src/main/java/com/google/errorprone/hubspot/module/ModuleState.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/module/ModuleState.java
@@ -16,6 +16,8 @@
 
 package com.google.errorprone.hubspot.module;
 
+import com.google.common.base.Preconditions;
+import com.google.errorprone.matchers.Description;
 import java.util.Map;
 
 import com.google.errorprone.BugPattern.SeverityLevel;
@@ -59,8 +61,14 @@ public class ModuleState {
   }
 
   public void reportMatch(ModuleDescription moduleDescription) {
-    if (moduleDescription == null || moduleDescription == ModuleDescription.NO_MATCH) {
+    Preconditions.checkNotNull(moduleDescription, "Use ModuleDescription.NO_MATCH to denote an absent finding.");
+    if (moduleDescription == ModuleDescription.NO_MATCH) {
       return;
+    }
+
+    SeverityLevel override = getSeverityMap().get(moduleDescription.getCheckName());
+    if (override != null) {
+      moduleDescription = moduleDescription.applySeverityOverride(override);
     }
 
     listenerFactory


### PR DESCRIPTION
This should allow our normal rollout process to work for module checks

@Xcelled @stevegutz @snommit-mit 