### PR TITLE
Add EPOptions to context sooner

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
+++ b/check_api/src/main/java/com/google/errorprone/BaseErrorProneJavaCompiler.java
@@ -93,6 +93,7 @@ public class BaseErrorProneJavaCompiler implements JavaCompiler {
   static void addTaskListener(
       JavacTask javacTask, ScannerSupplier scannerSupplier, ErrorProneOptions errorProneOptions) {
     Context context = ((BasicJavacTask) javacTask).getContext();
+    context.put(ErrorProneOptions.class, errorProneOptions);
     checkCompilePolicy(Options.instance(context).get("compilePolicy"));
     setupMessageBundle(context);
     RefactoringCollection[] refactoringCollection = {null};

--- a/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
+++ b/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java
@@ -115,7 +115,6 @@ public class ErrorProneAnalyzer implements TaskListener {
     this.descriptionListenerFactory = checkNotNull(descriptionListenerFactory);
 
     Context errorProneContext = new SubContext(context);
-    errorProneContext.put(ErrorProneOptions.class, errorProneOptions);
     this.context = errorProneContext;
   }
 


### PR DESCRIPTION
When ep is run in patch mode, it creates a second task listener at a later point that doesn't have the EP options set on the context. To fix, we'll just set the options even earlier in the cycle.

@jaredstehler @stevie400 @suruuK 