### PR TITLE
Expose UnusedVariable#buildUnusedVarFixes for overriding

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/UnusedVariable.java
@@ -405,7 +405,7 @@ public class UnusedVariable extends BugChecker implements CompilationUnitTreeMat
     return firstNonNull(path.getParentPath().getLeaf().accept(new Visitor(), null), false);
   }
 
-  private static ImmutableList<SuggestedFix> buildUnusedVarFixes(
+  protected ImmutableList<SuggestedFix> buildUnusedVarFixes(
       Symbol varSymbol, List<TreePath> usagePaths, VisitorState state) {
     // Don't suggest a fix for fields annotated @Inject: we can warn on them, but they *could* be
     // used outside the class.


### PR DESCRIPTION
This is the easiest way to change the fixes we apply. The problem we're seeing is that error-prone will give us two fixes for unusued method assignments, and the one it ends up applying remove the method call entirely, dropping any potential side-effects.

@Xcelled @suruuK @jaredstehler 