### PR TITLE
Catch throwable instead of exception

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/scanner/ErrorProneScanner.java
+++ b/check_api/src/main/java/com/google/errorprone/scanner/ErrorProneScanner.java
@@ -451,7 +451,7 @@ public class ErrorProneScanner extends Scanner {
           reportMatch(
               processingFunction.process(matcher, tree, stateWithSuppressionInformation),
               stateWithSuppressionInformation);
-        } catch (Exception | AssertionError t) {
+        } catch (Throwable t) {
           if (HubSpotUtils.isErrorHandlingEnabled(errorProneOptions)) {
             HubSpotMetrics.instance(oldState.context).recordError(matcher);
           } else {


### PR DESCRIPTION
They changed this on us in https://github.com/HubSpot/error-prone/commit/c391bae493634a10acb778bb3921dd9e2efdfb47. They seem to be advocating for allowing some errors, such as OOMs to bubble up, which seems reasonable. 

Any thoughts on if we want to do something smart here? We could just add [`LinkageError`](https://docs.oracle.com/javase%2F7%2Fdocs%2Fapi%2F%2F/java/lang/LinkageError.html) to the catch as its subclasses are what keep biting us. Or we could just go with `Throwable` here like we currently do elsewhere and move on.

@Xcelled @suruuK @jaredstehler @PtrTeixeira @ggs5427 