### PR TITLE
Check for chance of class init deadlock with non-nested subclass

### DIFF
--- a/core/src/main/java/com/google/errorprone/bugpatterns/ClassInitializationDeadlock.java
+++ b/core/src/main/java/com/google/errorprone/bugpatterns/ClassInitializationDeadlock.java
@@ -144,7 +144,7 @@ public class ClassInitializationDeadlock extends BugChecker implements BugChecke
         if (!use.isSubClass(classSymbol, state.getTypes())) {
           return;
         }
-        if (!isStatic(use)) {
+        if (use.isEnclosedBy(classSymbol) && !isStatic(use)) {
           // Nested inner classes implicitly take the enclosing instance as a constructor parameter,
           // and can't be initialized without first initializing their containing class.
           return;

--- a/core/src/test/java/com/google/errorprone/bugpatterns/ClassInitializationDeadlockTest.java
+++ b/core/src/test/java/com/google/errorprone/bugpatterns/ClassInitializationDeadlockTest.java
@@ -296,4 +296,17 @@ public class ClassInitializationDeadlockTest {
             "}")
         .doTest();
   }
+
+  @Test
+  public void nonNestedSubclass() {
+    testHelper
+        .addSourceLines(
+            "Foo.java",
+            "class A {",
+            "  // BUG: Diagnostic contains:",
+            "  private static Object cycle = new B();",
+            "}",
+            "class B extends A {}")
+        .doTest();
+  }
 }


### PR DESCRIPTION
This PR fixes a bug with the `ClassInitializationDeadlock` check to find chances for a class init deadlock when the subclass isn't nested within the superclass. This situation [can still produce a deadlock](https://gist.github.com/tkindy/a83ec86c95bb7d7119f6b208d239ea94).

This should probably be upstreamed, but I'll start with our fork.

@jaredstehler @stevie400 @Xcelled 