### PR TITLE
Record error details instead of just the check name

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotMetrics.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotMetrics.java
@@ -25,11 +25,14 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.google.common.base.Strings;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
+import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Multimaps;
 import com.google.common.util.concurrent.AtomicLongMap;
 import com.google.errorprone.DescriptionListener;
 import com.google.errorprone.ErrorProneTimings;
@@ -37,27 +40,6 @@ import com.google.errorprone.matchers.Suppressible;
 import com.sun.tools.javac.util.Context;
 
 public class HubSpotMetrics {
-
-  enum ErrorType {
-    EXCEPTIONS("errorProneExceptions"),
-    MISSING("errorProneMissingChecks"),
-    INIT_ERRORS("errorProneInitErrors"),
-    LISTENER_INIT_ERRORS("errorProneListenerInitErrors"),
-    LISTENER_ON_DESCRIBE_ERROR("errorProneListenerDescribeErrors"),
-    UNHANDLED_ERRORS("errorProneUnhandledErrors");
-
-    final String value;
-
-    ErrorType(String value) {
-      this.value = value;
-    }
-
-    @JsonValue
-    public String getValue() {
-      return value;
-    }
-  }
-
   public static synchronized HubSpotMetrics instance(Context context) {
     HubSpotMetrics metrics = context.get(HubSpotMetrics.class);
 
@@ -77,26 +59,23 @@ public class HubSpotMetrics {
     return metrics;
   }
 
-  private final ConcurrentHashMap<ErrorType, Set<String>> errors;
+  private final ErrorState errors;
   private final AtomicLongMap<String> timings;
-
   private final Supplier<FileManager> fileManagerSupplier;
 
 
   HubSpotMetrics(Supplier<FileManager> fileManagerSupplier) {
-    this.errors = new ConcurrentHashMap<>();
+    this.errors = new ErrorState();
     this.timings = AtomicLongMap.create();
     this.fileManagerSupplier = fileManagerSupplier;
   }
 
-  public void recordError(Suppressible s) {
-    errors.computeIfAbsent(ErrorType.EXCEPTIONS, ignored -> ConcurrentHashMap.newKeySet())
-        .add(s.canonicalName());
+  public void recordError(Suppressible s, Throwable t) {
+    errors.exceptions.put(s.canonicalName(), t);
   }
 
   public void recordMissingCheck(String checkName) {
-    errors.computeIfAbsent(ErrorType.MISSING, ignored -> ConcurrentHashMap.newKeySet())
-        .add(checkName);
+    errors.missing.add(checkName);
   }
 
   public void recordTimings(Context context) {
@@ -106,13 +85,11 @@ public class HubSpotMetrics {
   }
 
   public void recordListenerDescribeError(DescriptionListener listener, Throwable t) {
-    errors.computeIfAbsent(ErrorType.LISTENER_ON_DESCRIBE_ERROR, ignored -> ConcurrentHashMap.newKeySet())
-        .add(toErrorMessage(t));
+    errors.listenerOnDescribeErrors.put(listener.getClass().getCanonicalName(), t);
   }
 
   public void recordUncaughtException(Throwable throwable) {
-    errors.computeIfAbsent(ErrorType.UNHANDLED_ERRORS, ignored -> ConcurrentHashMap.newKeySet())
-        .add(toErrorMessage(throwable));
+    errors.unhandledErrors.add(throwable);
 
     fileManagerSupplier.get().getUncaughtExceptionPath().ifPresent(p -> {
       // this should only ever be called once so overwriting is fine
@@ -126,22 +103,12 @@ public class HubSpotMetrics {
     });
   }
 
-  public void recordCheckLoadError(Throwable t) {
-    errors.computeIfAbsent(ErrorType.INIT_ERRORS, ignored -> ConcurrentHashMap.newKeySet())
-        .add(toErrorMessage(t));
+  public void recordCheckLoadError(String name, Throwable t) {
+    errors.initErrors.put(name, t);
   }
 
-  public void recordListenerInitError(Throwable t) {
-    errors.computeIfAbsent(ErrorType.LISTENER_INIT_ERRORS, ignored -> ConcurrentHashMap.newKeySet())
-        .add(toErrorMessage(t));
-  }
-
-  private static String toErrorMessage(Throwable e) {
-    if (Strings.isNullOrEmpty(e.getMessage())) {
-      return "Unknown error";
-    } else {
-      return e.getMessage();
-    }
+  public void recordListenerInitError(String name, Throwable t) {
+    errors.listenerInitErrors.put(name, t);
   }
 
   private void write() {
@@ -159,4 +126,23 @@ public class HubSpotMetrics {
         .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
   }
 
+  private static class ErrorState {
+    @JsonProperty("errorProneExceptions")
+    public final Multimap<String, Throwable> exceptions = Multimaps.synchronizedMultimap(HashMultimap.create());
+
+    @JsonProperty("errorProneMissingChecks")
+    public final Set<String> missing = ConcurrentHashMap.newKeySet();
+
+    @JsonProperty("errorProneInitErrors")
+    public final Multimap<String, Throwable> initErrors = Multimaps.synchronizedMultimap(HashMultimap.create());
+
+    @JsonProperty("errorProneListenerInitErrors")
+    public final Multimap<String, Throwable> listenerInitErrors = Multimaps.synchronizedMultimap(HashMultimap.create());
+
+    @JsonProperty("errorProneListenerDescribeErrors")
+    public final Multimap<String, Throwable> listenerOnDescribeErrors = Multimaps.synchronizedMultimap(HashMultimap.create());
+
+    @JsonProperty("errorProneUnhandledErrors")
+    public final Set<Throwable> unhandledErrors = ConcurrentHashMap.newKeySet();
+  }
 }

--- a/check_api/src/main/java/com/google/errorprone/hubspot/module/CompilationEndAwareErrorPoneAnalyzer.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/module/CompilationEndAwareErrorPoneAnalyzer.java
@@ -154,7 +154,7 @@ public class CompilationEndAwareErrorPoneAnalyzer implements TaskListener {
             );
           } catch (Throwable t) {
             if (HubSpotUtils.isErrorHandlingEnabled(errorProneOptions)) {
-              HubSpotMetrics.instance(context).recordError(bugChecker);
+              HubSpotMetrics.instance(context).recordError(bugChecker, t);
             } else {
               throw t;
             }

--- a/check_api/src/main/java/com/google/errorprone/scanner/ErrorProneScanner.java
+++ b/check_api/src/main/java/com/google/errorprone/scanner/ErrorProneScanner.java
@@ -453,7 +453,7 @@ public class ErrorProneScanner extends Scanner {
               stateWithSuppressionInformation);
         } catch (Exception | AssertionError t) {
           if (HubSpotUtils.isErrorHandlingEnabled(errorProneOptions)) {
-            HubSpotMetrics.instance(oldState.context).recordError(matcher);
+            HubSpotMetrics.instance(oldState.context).recordError(matcher, getError(matcher, t));
           } else {
             handleError(matcher, t);
           }
@@ -905,6 +905,21 @@ public class ErrorProneScanner extends Scanner {
     VisitorState state =
         processMatchers(wildcardMatchers, tree, WildcardTreeMatcher::matchWildcard, visitorState);
     return super.visitWildcard(tree, state);
+  }
+
+  protected Throwable getError(Suppressible s, Throwable t) {
+    if (t instanceof ErrorProneError) {
+      return t;
+    }
+    if (t instanceof CompletionFailure) {
+      return t;
+    }
+    TreePath path = getCurrentPath();
+    return new ErrorProneError(
+        s.canonicalName(),
+        t,
+        (DiagnosticPosition) path.getLeaf(),
+        path.getCompilationUnit().getSourceFile());
   }
 
   /**

--- a/check_api/src/main/java/com/google/errorprone/scanner/ErrorProneScanner.java
+++ b/check_api/src/main/java/com/google/errorprone/scanner/ErrorProneScanner.java
@@ -907,12 +907,17 @@ public class ErrorProneScanner extends Scanner {
     return super.visitWildcard(tree, state);
   }
 
+  /**
+   *  This is copied from the body of #handleError. Ideally we'd change that method to call this one,
+   *  but that would force us to declare `throws Throwable` which turns into a huge mess. To avoid
+   *  all of that we just copy the body verbatim.
+   */
   protected Throwable getError(Suppressible s, Throwable t) {
     if (t instanceof ErrorProneError) {
-      return t;
+      return  (ErrorProneError) t;
     }
     if (t instanceof CompletionFailure) {
-      return t;
+      return  (CompletionFailure) t;
     }
     TreePath path = getCurrentPath();
     return new ErrorProneError(


### PR DESCRIPTION
When checking into some of our checks that were throwing errors, I noticed it was very tedious trying to find out what the error actually was, something that will probably discourage people from finding/fixing the errors.

This PR changes our metrics recorder to also store the error information and write it out to the `error-prone-exceptions.json` file which can be viewed in the Blazar UI.

@suruuK @stevie400 @jaredstehler @PtrTeixeira @ggs5427 