### PR TITLE
Record error details instead of just the check name take 2

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotMetrics.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotMetrics.java
@@ -39,9 +39,7 @@ import com.google.common.util.concurrent.AtomicLongMap;
 import com.google.errorprone.DescriptionListener;
 import com.google.errorprone.ErrorProneTimings;
 import com.google.errorprone.matchers.Suppressible;
-import com.sun.source.util.TreePath;
 import com.sun.tools.javac.util.Context;
-import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 
 public class HubSpotMetrics {
   public static synchronized HubSpotMetrics instance(Context context) {
@@ -130,7 +128,7 @@ public class HubSpotMetrics {
         .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
   }
 
-  private static class ErrorState {
+  public static class ErrorState {
     @JsonProperty("errorProneExceptions")
     public final Multimap<String, Map<String, ?>> exceptions = Multimaps.synchronizedMultimap(HashMultimap.create());
 

--- a/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotMetrics.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotMetrics.java
@@ -152,26 +152,10 @@ public class HubSpotMetrics {
   }
 
   public static Map<String, ?> getErrorDescription(Throwable t) {
-    HashSet<Throwable> seen = new HashSet<>();
-    seen.add(t);
-
-    return throwableToMap(t, seen);
-  }
-
-  private static ImmutableMap<String, ?> throwableToMap(Throwable t, HashSet<Throwable> seen) {
-    ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object>builder()
+    return ImmutableMap.<String, String>builder()
         .put("message", t.getMessage())
-        .put("class", t.getClass())
-        .put("stackTrace", Throwables.getStackTraceAsString(t));
-
-    if (t.getCause() != null && seen.add(t.getCause())) {
-      builder.put("cause", throwableToMap(t.getCause(), new HashSet<>(seen)));
-    }
-
-    if (t.getSuppressed().length != 0) {
-      builder.put("suppressed", Arrays.stream(t.getSuppressed()).filter(seen::add).map(s -> throwableToMap(s, new HashSet<>(seen))));
-    }
-
-    return builder.build();
+        .put("class", t.getClass().getCanonicalName())
+        .put("stackTrace", Throwables.getStackTraceAsString(t))
+        .build();
   }
 }

--- a/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotMetrics.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotMetrics.java
@@ -28,6 +28,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Suppliers;
 import com.google.common.base.Throwables;
@@ -128,6 +130,7 @@ public class HubSpotMetrics {
         .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
   }
 
+  @JsonInclude(Include.NON_EMPTY)
   public static class ErrorState {
     @JsonProperty("errorProneExceptions")
     public final Multimap<String, Map<String, ?>> exceptions = Multimaps.synchronizedMultimap(HashMultimap.create());

--- a/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotUtils.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotUtils.java
@@ -72,6 +72,8 @@ public class HubSpotUtils {
         METRICS.ifPresent(metrics -> metrics.recordCheckLoadError(name, e));
       }
     }
+
+    return ScannerSupplier.fromBugCheckerInfos(builder.build());
   }
 
   public static List<DescriptionListener> loadDescriptionListeners(Iterable<CustomDescriptionListenerFactory> factories, DescriptionListenerResources resources) {

--- a/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotUtils.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/HubSpotUtils.java
@@ -22,6 +22,7 @@ import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.BugCheckerInfo;
@@ -57,25 +58,36 @@ public class HubSpotUtils {
   public static ScannerSupplier createScannerSupplier(Iterable<BugChecker> extraBugCheckers) {
     ImmutableList.Builder<BugCheckerInfo> builder = ImmutableList.builder();
     Iterator<BugChecker> iter = extraBugCheckers.iterator();
+
+
+    AtomicInteger i = new AtomicInteger(0);
+
     while (iter.hasNext()) {
+      BugChecker checker = null;
       try {
-        Class<? extends BugChecker> checker = iter.next().getClass();
-        builder.add(BugCheckerInfo.create(checker));
+        checker = iter.next();
+        builder.add(BugCheckerInfo.create(checker.getClass()));
       } catch (Throwable e) {
-        METRICS.ifPresent(metrics -> metrics.recordCheckLoadError(e));
+        String name = checker == null ? ("Unknown_" + i.incrementAndGet()) : checker.canonicalName();
+        METRICS.ifPresent(metrics -> metrics.recordCheckLoadError(name, e));
       }
     }
-    return ScannerSupplier.fromBugCheckerInfos(builder.build());
   }
 
   public static List<DescriptionListener> loadDescriptionListeners(Iterable<CustomDescriptionListenerFactory> factories, DescriptionListenerResources resources) {
     Iterator<CustomDescriptionListenerFactory> iter = factories.iterator();
     ImmutableList.Builder<DescriptionListener> listeners = ImmutableList.builder();
+
+
+    AtomicInteger i = new AtomicInteger(0);
     while (iter.hasNext()) {
+      CustomDescriptionListenerFactory listener = null;
       try {
-        listeners.add(iter.next().createFactory(resources));
+        listener = iter.next();
+        listeners.add(listener.createFactory(resources));
       } catch (Throwable t) {
-        METRICS.ifPresent(metrics -> metrics.recordListenerInitError(t));
+        String name = listener == null ? ("Unknown_" + i.incrementAndGet()) : listener.getClass().getCanonicalName();
+        METRICS.ifPresent(metrics -> metrics.recordListenerInitError(name, t));
       }
     }
 

--- a/check_api/src/main/java/com/google/errorprone/hubspot/module/CompilationEndAwareErrorPoneAnalyzer.java
+++ b/check_api/src/main/java/com/google/errorprone/hubspot/module/CompilationEndAwareErrorPoneAnalyzer.java
@@ -154,7 +154,7 @@ public class CompilationEndAwareErrorPoneAnalyzer implements TaskListener {
             );
           } catch (Throwable t) {
             if (HubSpotUtils.isErrorHandlingEnabled(errorProneOptions)) {
-              HubSpotMetrics.instance(context).recordError(bugChecker);
+              HubSpotMetrics.instance(context).recordError(bugChecker, HubSpotMetrics.getErrorDescription(t));
             } else {
               throw t;
             }


### PR DESCRIPTION
The previous version ended up recursing a lot due to internal state in the errors that we don't actually care about. This version explicitly picks properties to include.

@suruuK @stevie400 @jaredstehler @PtrTeixeira @ggs5427 