### PR TITLE
Add Description#withPosition

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/matchers/Description.java
+++ b/check_api/src/main/java/com/google/errorprone/matchers/Description.java
@@ -152,6 +152,19 @@ public class Description {
         Optional.ofNullable(severity), metadata);
   }
 
+  @CheckReturnValue
+  public Description withPosition(DiagnosticPosition position) {
+    return new Description(
+      position,
+      checkName,
+      rawMessage,
+      linkUrl,
+      fixes,
+      severity,
+      metadata
+    );
+  }
+
   /**
    * Construct the link text to include in the compiler error message. Returns null if there is no
    * link.


### PR DESCRIPTION
We could try to make this fancy and not do things on `NO_MATCH` or if the position is the same as the current one, but it seems best just to file the style in `applySeverityOverride`

@Xcelled @suruuK @jaredstehler @PtrTeixeira @ggs5427 @tkindy 