### PR TITLE
Catch Throwable in ErrorProneScanner

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/scanner/ErrorProneScanner.java
+++ b/check_api/src/main/java/com/google/errorprone/scanner/ErrorProneScanner.java
@@ -453,7 +453,7 @@ public class ErrorProneScanner extends Scanner {
           reportMatch(
               processingFunction.process(matcher, tree, stateWithSuppressionInformation),
               stateWithSuppressionInformation);
-        } catch (Exception | AssertionError t) {
+        } catch (Throwable t) {
           if (HubSpotUtils.isErrorHandlingEnabled(errorProneOptions)) {
             HubSpotMetrics.instance(oldState.context).recordError(matcher, getErrorDescription(t));
           } else {


### PR DESCRIPTION
We're getting `java.lang.ExceptionInInitializerError` and failing the build.

@Xcelled @suruuK @jaredstehler