### PR TITLE
Remove redundant JDK toolchain version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,6 @@
         <configuration>
           <toolchains>
             <jdk>
-              <version>17</version>
               <version>24</version>
             </jdk>
           </toolchains>


### PR DESCRIPTION
Cherry-pick of https://github.com/google/error-prone/pull/4742.