### PR TITLE
Fix class not founds errors

### DIFF
--- a/check_api/src/main/java/com/google/errorprone/fixes/ErrorProneEndPosTable.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/ErrorProneEndPosTable.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.fixes;
+
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.Tree;
+import com.sun.tools.javac.tree.EndPosTable;
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.util.JCDiagnostic;
+
+/** A compatibility wrapper around {@code EndPosTable}. */
+public interface ErrorProneEndPosTable {
+
+  static ErrorProneEndPosTable create(CompilationUnitTree unit) {
+    EndPosTable endPosTable = ((JCTree.JCCompilationUnit) unit).endPositions;
+    return pos -> pos.getEndPosition(endPosTable);
+  }
+
+  default int getEndPosition(Tree tree) {
+    return getEndPosition((JCDiagnostic.DiagnosticPosition) tree);
+  }
+
+  default int getEndPosition(JCTree tree) {
+    return getEndPosition((JCDiagnostic.DiagnosticPosition) tree);
+  }
+
+  int getEndPosition(JCDiagnostic.DiagnosticPosition pos);
+
+  static int getEndPosition(Tree tree, CompilationUnitTree unit) {
+    return getEndPosition((JCDiagnostic.DiagnosticPosition) tree, unit);
+  }
+
+  static int getEndPosition(JCTree tree, CompilationUnitTree unit) {
+    return getEndPosition((JCDiagnostic.DiagnosticPosition) tree, unit);
+  }
+
+  static int getEndPosition(JCDiagnostic.DiagnosticPosition pos, CompilationUnitTree unit) {
+    return create(unit).getEndPosition(pos);
+  }
+}

--- a/check_api/src/main/java/com/google/errorprone/fixes/ErrorPronePosition.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/ErrorPronePosition.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.fixes;
+
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
+
+/** A compatibility wrapper around {@link DiagnosticPosition}. */
+public interface ErrorPronePosition {
+  static ErrorPronePosition from(JCTree node) {
+    return new WrappedDiagnosticPosition(node);
+  }
+
+  static ErrorPronePosition from(DiagnosticPosition pos) {
+    return new WrappedDiagnosticPosition(pos);
+  }
+
+  int getStartPosition();
+
+  int getPreferredPosition();
+
+  JCTree getTree();
+
+  int getEndPosition(ErrorProneEndPosTable endPosTable);
+}

--- a/check_api/src/main/java/com/google/errorprone/fixes/WrappedDiagnosticPosition.java
+++ b/check_api/src/main/java/com/google/errorprone/fixes/WrappedDiagnosticPosition.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 The Error Prone Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.errorprone.fixes;
+
+import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
+
+record WrappedDiagnosticPosition(DiagnosticPosition pos) implements ErrorPronePosition {
+
+  @Override
+  public int getStartPosition() {
+    return pos.getStartPosition();
+  }
+
+  @Override
+  public int getPreferredPosition() {
+    return pos.getPreferredPosition();
+  }
+
+  @Override
+  public JCTree getTree() {
+    return pos.getTree();
+  }
+
+  @Override
+  public int getEndPosition(ErrorProneEndPosTable endPosTable) {
+    return endPosTable.getEndPosition(pos);
+  }
+}


### PR DESCRIPTION
Add these wrapper classes to fix class not found errors after changes to the upstream

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.14.0:compile (default-compile) on project BuildInsightsModels: Compilation failure
[ERROR] error: An unhandled exception was thrown by the Error Prone static analysis plugin.
[ERROR]      Please report this at https://github.com/google/error-prone/issues/new and include the following, as well as a reproducing code sample (if possible):
[ERROR]   
[ERROR]      error-prone version: 2.45.0-vba-namespace-SNAPSHOT
[ERROR]      BugPattern: (see stack trace)
[ERROR]      Stack Trace:
[ERROR]      java.lang.NoClassDefFoundError: com/google/errorprone/fixes/ErrorPronePosition
[ERROR]   	at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
[ERROR]   	at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:2985)
[ERROR]   	at java.base/java.lang.Class.getConstructor0(Class.java:3180)
[ERROR]   	at java.base/java.lang.Class.getConstructor(Class.java:2199)
[ERROR]   	at java.base/java.util.ServiceLoader.getConstructor(ServiceLoader.java:623)
[ERROR]   	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1111)
[ERROR]   	at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1142)
[ERROR]   	at java.base/java.util.ServiceLoader$1.hasNext(ServiceLoader.java:1164)
```